### PR TITLE
useFetch 커스텀훅

### DIFF
--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+
+const useFetch = (getAPI, initialValue) => {
+  // getAPI : getAPI 함수, initialValue : response JSON 데이터 기본값
+  const [data, setData] = useState(initialValue);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const result = await getAPI();
+        setData(result);
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      }
+    };
+
+    fetchData(); // eslint-disable-next-line
+  }, []);
+
+  return data; // data : response JSON
+};
+
+export default useFetch;


### PR DESCRIPTION
### `useFetch()`
- GET API 요청 함수에 대한 커스텀 훅입니다.
- 개별 컴포넌트에서의 useState/useEffect 사용을 줄이고, fetch 로직을 재사용할 수 있습니다.

### 사용법
- 첫 번째 파라미터 `getAPI` : get 요청 함수
- 두 번째 파라미터 `initialValue` : response JSON 데이터 기본값
- 리턴값 `data` : response JSON 객체


### [사용 예시 1](https://github.com/rolling-sprint/rolling/pull/33/commits/10f8defaa2010ea1f001ab4c9bf519109066cbfa) : [MyPaperCardList] 롤링페이퍼 수신자 정보, 메시지 정보를 받아올 때
### [사용 예시 2](https://github.com/rolling-sprint/rolling/pull/33/commits/8487e7e41be8f953a0c9684943b02cd8744d7a8e) : [ProfileImage.jsx] 메시지폼 내 프로필이미지 url을 받아올 때

### 예시 (ProfileImage.jsx 에서 프로필 이미지를 패치받을 때 사용함)
<img width="972" alt="스크린샷 2024-05-13 오후 6 16 59" src="https://github.com/rolling-sprint/rolling/assets/64190056/67fa6a09-3de2-4e52-b1bc-21fbdcfe1b21">
<img width="1229" alt="스크린샷 2024-05-13 오후 6 16 35" src="https://github.com/rolling-sprint/rolling/assets/64190056/0c02b556-14ae-4474-a61a-717ee645083f">
